### PR TITLE
fix(frontend): Type checks failing on pipelines but working locally

### DIFF
--- a/frontend/src/composables/utils.ts
+++ b/frontend/src/composables/utils.ts
@@ -1,3 +1,5 @@
+import type { useToast } from "@nuxt/ui/runtime/composables/index.js";
+
 type ApiError = {
 	code: string;
 	detail: string;

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,12 +1,6 @@
 {
 	"extends": "@vue/tsconfig/tsconfig.dom.json",
-	"include": [
-		"env.d.ts",
-		"src/**/*",
-		"src/**/*.vue",
-		"auto-imports.d.ts",
-		"components.d.ts"
-	],
+	"include": ["env.d.ts", "src/**/*", "src/**/*.vue"],
 	"exclude": ["src/**/__tests__/*"],
 	"compilerOptions": {
 		"tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",


### PR DESCRIPTION
Since nuxt-ui uses auto-imports, the auto-import files were included if you'd run vite, but that was not the case in the pipelines. 
To fix the issues since we don't use auto imports in the rest of the app, we don't include them in the tsconfig.
With this type checks fails locally the same as in the pipelines.